### PR TITLE
Adding patch to allow for 500k baud rate with screen.

### DIFF
--- a/screen.rb
+++ b/screen.rb
@@ -17,8 +17,8 @@ class Screen < Formula
     
     # This patch is to enable 500kbps as a possible baud rate
     patch :p3 do
-      url "https://gist.githubusercontent.com/JamesHagerman/4f13173589c3aa2b0ef7/raw/36ab5f55f59f11d01cd5b95547f5cc06ee5c5e08/gistfile1.txt"
-      sha1 "1b643a99adb8bc3881bbec333d77b11772901bef"
+      url "https://gist.githubusercontent.com/JamesHagerman/a369606bc6cb34b6a433/raw/c3d3df5fe92a05373cc9f7cb9d1449fd6001894c/add500kbp.diff"
+      sha1 "1eaa56db738357ad8b4b6dc51e5230ae44713e18"
     end
   end
 

--- a/screen.rb
+++ b/screen.rb
@@ -17,8 +17,8 @@ class Screen < Formula
     
     # This patch is to enable 500kbps as a possible baud rate
     patch :p3 do
-      url "https://gist.githubusercontent.com/JamesHagerman/a369606bc6cb34b6a433/raw/c3d3df5fe92a05373cc9f7cb9d1449fd6001894c/add500kbp.diff"
-      sha1 "1eaa56db738357ad8b4b6dc51e5230ae44713e18"
+      url "https://gist.githubusercontent.com/JamesHagerman/a369606bc6cb34b6a433/raw/12017a74085e66d64bea4899645a6bb0d113dc39/add500kbp.diff"
+      sha1 "e07e6e375dbfa5770f2690ada288012561568986"
     end
   end
 

--- a/screen.rb
+++ b/screen.rb
@@ -17,8 +17,8 @@ class Screen < Formula
     
     # This patch is to enable 500kbps as a possible baud rate
     patch :p3 do
-      url "https://gist.githubusercontent.com/JamesHagerman/a369606bc6cb34b6a433/raw/c3d3df5fe92a05373cc9f7cb9d1449fd6001894c/add500kbp.diff"
-      sha1 "1eaa56db738357ad8b4b6dc51e5230ae44713e18"
+      url "https://gist.githubusercontent.com/JamesHagerman/4f13173589c3aa2b0ef7/raw/36ab5f55f59f11d01cd5b95547f5cc06ee5c5e08/gistfile1.txt"
+      sha1 "1b643a99adb8bc3881bbec333d77b11772901bef"
     end
   end
 

--- a/screen.rb
+++ b/screen.rb
@@ -14,6 +14,12 @@ class Screen < Formula
       url "https://gist.githubusercontent.com/yujinakayama/4608863/raw/75669072f227b82777df25f99ffd9657bd113847/gistfile1.diff"
       sha1 "93d611f1f46c7bbca5f9575304913bd1c38e183b"
     end
+    
+    # This patch is to enable 500kbps as a possible baud rate
+    patch :p3 do
+      url "https://gist.githubusercontent.com/JamesHagerman/a369606bc6cb34b6a433/raw/c3d3df5fe92a05373cc9f7cb9d1449fd6001894c/add500kbp.diff"
+      sha1 "1eaa56db738357ad8b4b6dc51e5230ae44713e18"
+    end
   end
 
   head do


### PR DESCRIPTION
This patch is left over from a patch submitted to GNU Screen screen-devel list back in 2011. Somehow it never made it into screen... but I can't find information on why it hasn't been included. This is the original mailing list post:

https://lists.gnu.org/archive/html/screen-devel/2011-11/msg00012.html

There are a few situations where a 500k baud rate is pretty useful. If nothing else, a fairly large number of modern car's OBDII ports run at 500k baud. Without this patch, screen is unable to keep up with the OBDII port in logging situations.