### PR TITLE
tidy update HEAD to new home of tidy (htacg).

### DIFF
--- a/tidy.rb
+++ b/tidy.rb
@@ -18,7 +18,8 @@ class Tidy < Formula
 
 
   head do
-    url "https://github.com/w3c/tidy-html5.git"
+    # Head homepage is now "http://www.html-tidy.org/".
+    url "https://github.com/htacg/tidy-html5.git"
 
     depends_on "cmake" => :build
   end
@@ -36,6 +37,8 @@ class Tidy < Formula
         system "cmake", "../..", *std_cmake_args
         system "make", "install"
       end
+      # Binary is now named 'tidy5' so symlink it to 'tidy'.
+      bin.install_symlink "tidy5" => "tidy"
     end
   end
 end


### PR DESCRIPTION
Updated HEAD of tidy to the version of the *HTML Tidy Advocacy Community Group* (HTACG). It's the development group now responsible for the continued support, development, and evolution of HTML Tidy.
http://www.htacg.org/
http://www.html-tidy.org/

Maybe we should make linking of `tidy5` to `tidy` optional?