### PR TITLE
nano 2.4

### DIFF
--- a/nano.rb
+++ b/nano.rb
@@ -11,6 +11,7 @@ class Nano < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "homebrew/dupes/ncurses"
+  depends_on "glib"
 
   def install
     system "./configure", "--disable-debug",

--- a/nano.rb
+++ b/nano.rb
@@ -2,18 +2,11 @@ require 'formula'
 
 class Nano < Formula
   homepage 'http://www.nano-editor.org/'
-  url 'http://www.nano-editor.org/dist/v2.2/nano-2.2.6.tar.gz'
-  sha1 'f2a628394f8dda1b9f28c7e7b89ccb9a6dbd302a'
+  url 'http://www.nano-editor.org/dist/v2.4/nano-2.4.0.tar.gz'
+  sha1 '55639cbac2d38febf16780b912b036f2023534d1'
   head 'svn://svn.sv.gnu.org/nano/trunk/nano'
-
-  devel do
-    url 'http://www.nano-editor.org/dist/v2.3/nano-2.3.6.tar.gz'
-    sha1 '7dd39f21bbb1ab176158e0292fd61c47ef681f6d'
-
-    # Fixes regex in the default nanorc.nanorc; fixed upstream:
-    # http://savannah.gnu.org/bugs/index.php?42929
-    patch :DATA
-  end
+  # see https://savannah.gnu.org/bugs/?44609
+  patch :DATA
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
@@ -40,16 +33,14 @@ end
 
 
 __END__
-diff --git a/doc/syntax/nanorc.nanorc b/doc/syntax/nanorc.nanorc
-index fd66d6b..6e52942 100644
---- a/doc/syntax/nanorc.nanorc
-+++ b/doc/syntax/nanorc.nanorc
-@@ -7,7 +7,7 @@ icolor brightred "^[[:space:]]*((un)?(bind|set)|include|syntax|header|magic|lint
- 
- # Keywords
- icolor brightgreen "^[[:space:]]*(set|unset)[[:space:]]+(allow_insecure_backup|autoindent|backup|backwards|boldtext|casesensitive|const|cut|fill|historylog|locking|morespace|mouse|multibuffer|noconvert|nofollow|nohelp|nonewlines|nowrap|poslog|preserve|quickblank|quiet|rebinddelete|rebindkeypad|regexp|smarthome|smooth|softwrap|suspend|tabsize|tabstospaces|tempfile|undo|view|wordbounds)\>"
--icolor yellow "^[[:space:]]*set[[:space:]]+(functioncolor|keycolor||statuscolor|titlecolor)[[:space:]]+(bright)?(white|black|red|blue|green|yellow|magenta|cyan)?(,(white|black|red|blue|green|yellow|magenta|cyan))?\>"
-+icolor yellow "^[[:space:]]*set[[:space:]]+(functioncolor|keycolor|statuscolor|titlecolor)[[:space:]]+(bright)?(white|black|red|blue|green|yellow|magenta|cyan)?(,(white|black|red|blue|green|yellow|magenta|cyan))?\>"
- icolor brightgreen "^[[:space:]]*set[[:space:]]+(backupdir|brackets|functioncolor|keycolor|matchbrackets|operatingdir|punct|quotestr|speller|statuscolor|titlecolor|whitespace)[[:space:]]+"
- icolor brightgreen "^[[:space:]]*bind[[:space:]]+((\^|M-)([[:alpha:]]|space|[]]|[0-9_=+{}|;:'\",./<>\?-])|F([1-9]|1[0-6])|Ins|Del)[[:space:]]+[[:alpha:]]+[[:space:]]+[[:alpha:]]+[[:space:]]*$"
- icolor brightgreen "^[[:space:]]*unbind[[:space:]]+((\^|M-)([[:alpha:]]|space|[]]|[0-9_=+{}|;:'\",./<>\?-])|F([1-9]|1[0-6])|Ins|Del)[[:space:]]+[[:alpha:]]+[[:space:]]*$"
+--- a/src/text.c	2015-03-22 23:45:12.000000000 -0400
++++ b/src/text.c	2015-03-24 22:44:05.000000000 -0400
+@@ -2664,7 +2664,7 @@ const char *do_alt_speller(char *tempfil
+     ssize_t current_y_save = openfile->current_y;
+     ssize_t lineno_save = openfile->current->lineno;
+     struct stat spellfileinfo;
+-    __time_t timestamp;
++    time_t timestamp;
+     pid_t pid_spell;
+     char *ptr;
+     static int arglen = 3;


### PR DESCRIPTION
The patch for devel-2.3.6 has been fixed in 2.4 - so removed.

A minor patch is required to compile v2.4 on Mac OS X.
see https://savannah.gnu.org/bugs/?44609 .