### PR TITLE
remove awk, add nawk 20121220 (new formula)

### DIFF
--- a/awk.rb
+++ b/awk.rb
@@ -1,20 +1,58 @@
 class Awk < Formula
+  desc "Brian Kernighan's pattern scanning and processing language"
   homepage "http://www.cs.princeton.edu/~bwk/btl.mirror/"
   url "http://www.cs.princeton.edu/~bwk/btl.mirror/awk.tar.gz"
   version "20121220"
   sha256 "8dc092165c5a4e1449f964286483d06d0dbfba4b0bd003cb5dab30de8f6d9b83"
-
-  conflicts_with "gawk",
-    :because => "both install awk executables."
+  head "https://github.com/junghans/nawk.git", :branch => "gentoo"
 
   def install
-    ENV.O3 # Docs recommend higher optimization
-    # the yacc command the makefile uses results in build failures:
-    # /usr/bin/bison: missing operand after `awkgram.y'
-    # makefile believes -S to use sprintf instead of sprint, but the
-    # -S flag is not supported by `bison -y`
-    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}", "YACC=yacc -d"
-    bin.install "a.out" => "awk"
-    man1.install "awk.1"
+    # have to run bison first or parallel build fails
+    system "make", "YACC=bison -d -y", "ytab.o"
+    system "make"
+    bin.install "a.out" => "nawk"
+
+    (libexec/"xpg4bin").install_symlink bin/"nawk" => "awk"
+
+    cp "awk.1" => "awk.1.bak"
+
+    # install original manpage to xpg4man before rewriting to "nawk"
+    (libexec/"xpg4man"/"man1").install "awk.1"
+
+    mv "awk.1.bak" => "awk.1"
+
+    # refer to 'nawk' instead of 'awk' in man page, and add a couple of
+    # SEE ALSO items
+    [
+      ["awk", "nawk"], ["AWK", "NAWK"], ["Awk", "Nawk"],
+      [/^.IR sed \(1\)$/, ".IR sed (1),\n.IR gsed (1),\n.IR awk (1),\n.IR gawk (1)"],
+    ].each do |s|
+      inreplace "awk.1", *s
+    end
+
+    man1.install "awk.1" => "nawk.1"
+  end
+
+  def caveats; <<-EOS.undent
+    This is Brian Kernighan's "new awk" or "BWK awk". It has been
+    installed as "nawk", and you can access the man page as "man nawk".
+
+    If you want to use it as "awk" add the "xpg4bin" directory to your
+    PATH from your bashrc like:
+
+        PATH="#{opt_libexec}/xpg4bin:$PATH"
+
+    And you can access the man page by adding the "xpg4man" directory to
+    your MANPATH from your bashrc as follows:
+
+        MANPATH="#{opt_libexec}/xpg4man:$MANPATH"
+
+    EOS
+  end
+
+  test do
+    assert_match(/^Working!$/,
+      shell_output("#{bin}/nawk 'BEGIN { print \"Working!\"; exit(0); }'"),
+                )
   end
 end


### PR DESCRIPTION
This is the newest version available of Brian Kernighan's original nawk
awk interpreter. It is of interest to awk programmers testing their
programs on different versions of awk. It is installed as 'nawk' and the
man page as 'nawk.1' and so does not conflict with anything.

The old formula for nawk 'awk.rb' which instals as 'awk' and conflicts
with gawk is removed by this commit.

The man page is edited to refer to 'nawk' instead of 'awk'.

The github repo promises to collect patches and track new versions, it
uses the "gentoo" branch for this, which is set as head. If the author
adds more non-trivial patches to this branch and tags it I will switch
to using the tarballs from github instead. Currently there are just a
couple of trivial patches for the makefile. The "gentoo" branch of the
github repo is set as head.

The homepage and source url is set to Brian's site.

I previously tried to submit this to homebrew main here:

https://github.com/Homebrew/homebrew/pull/43140#event-407127068