### PR TITLE
update args using proper berkeley-db option

### DIFF
--- a/openldap.rb
+++ b/openldap.rb
@@ -31,7 +31,7 @@ class Openldap < Formula
       --localstatedir=#{var}
     ]
 
-    args << "--enable-bdb=no" << "--enable-hdb=no" if build.without? "berkeley-db"
+    args << "--enable-bdb=no" << "--enable-hdb=no" if build.without? "berkeley-db4"
     args << "--enable-memberof" if build.with? "memberof"
     args << "--enable-unique" if build.with? "unique"
     args << "--enable-sssvlv=yes" if build.with? "sssvlv"


### PR DESCRIPTION
With commit 2e9c4ff the optional dependency option "berkeley-db" was updated to use version 4, but the build option used below wasn't updated accordingly. This commit fixes disabling of HDB/BDB backends and allows to build OpenLDAP with Berkeley DB support.