### PR TITLE
Missing simlink for panel.h to `brew --prefix`/incude

### DIFF
--- a/ncurses.rb
+++ b/ncurses.rb
@@ -77,7 +77,7 @@ class Ncurses < Formula
 
     ln_s [
       "ncursesw/curses.h", "ncursesw/form.h", "ncursesw/ncurses.h",
-      "ncursesw/term.h", "ncursesw/termcap.h"], include
+      "ncursesw/panel.h", "ncursesw/term.h", "ncursesw/termcap.h"], include
   end
 
   test do


### PR DESCRIPTION
panel.h is missing in the include directory. Breaks llvm-lldb (and standard distros do place panel.h at the top of /usr/include, ex: centos)