### PR TITLE
ncurses.rb add missing panel.h to include

### DIFF
--- a/ncurses.rb
+++ b/ncurses.rb
@@ -77,7 +77,7 @@ class Ncurses < Formula
 
     ln_s [
       "ncursesw/curses.h", "ncursesw/form.h", "ncursesw/ncurses.h",
-      "ncursesw/term.h", "ncursesw/termcap.h"], include
+      "ncursesw/panel.h","ncursesw/term.h", "ncursesw/termcap.h"], include
   end
 
   test do


### PR DESCRIPTION
Breaks llvm-lldb compilation, most distros put panel.h at the include root, (centos)