### PR TITLE
fix: update sha256sum hash to current value

### DIFF
--- a/lapack.rb
+++ b/lapack.rb
@@ -13,13 +13,18 @@ class Lapack < Formula
 
   keg_only :provided_by_osx
 
+  option "with-doxygen", "Build man pages with Doxygen"
+  depends_on "doxygen" => :optional
+
   depends_on :fortran
   depends_on "cmake" => :build
 
   def install
-    system "mv", "make.inc.example", "make.inc"
-    system "make", "man"
-    man3.install Dir["DOCS/man/man3/*"]
+    if build.with? "doxygen"
+      system "mv", "make.inc.example", "make.inc"
+      system "make", "man"
+      man3.install Dir["DOCS/man/man3/*"]
+    end
     system "cmake", ".", "-DBUILD_SHARED_LIBS:BOOL=ON", "-DLAPACKE:BOOL=ON", *std_cmake_args
     system "make", "install"
   end

--- a/lapack.rb
+++ b/lapack.rb
@@ -10,10 +10,6 @@ class Lapack < Formula
     sha256 "ea53fdfa5b8c5fa0127ba056e74a3ce2f292a3094c6ea1f85a1d841732e56f05" => :mavericks
   end
 
-  resource "manpages" do
-    url "http://netlib.org/lapack/manpages.tgz"
-    sha256 "96d6d37b49e01143cf27e1980534ee21e01de6e93c1455c63d1e0a799f799dcb"
-  end
 
   keg_only :provided_by_osx
 
@@ -21,9 +17,11 @@ class Lapack < Formula
   depends_on "cmake" => :build
 
   def install
+    system "mv", "make.inc.example", "make.inc"
+    system "make", "man"
+    man3.install Dir["DOCS/man/man3/*"]
     system "cmake", ".", "-DBUILD_SHARED_LIBS:BOOL=ON", "-DLAPACKE:BOOL=ON", *std_cmake_args
     system "make", "install"
-    man.install resource("manpages")
   end
 
   test do

--- a/lapack.rb
+++ b/lapack.rb
@@ -12,7 +12,7 @@ class Lapack < Formula
 
   resource "manpages" do
     url "http://netlib.org/lapack/manpages.tgz"
-    sha256 "055da7402ea807cc16f6c50b71ac63d290f83a5f2885aa9f679b7ad11dd8903d"
+    sha256 "96d6d37b49e01143cf27e1980534ee21e01de6e93c1455c63d1e0a799f799dcb"
   end
 
   keg_only :provided_by_osx

--- a/lapack.rb
+++ b/lapack.rb
@@ -21,7 +21,7 @@ class Lapack < Formula
 
   def install
     if build.with? "doxygen"
-      system "mv", "make.inc.example", "make.inc"
+      mv "make.inc.example", "make.inc"
       system "make", "man"
       man3.install Dir["DOCS/man/man3/*"]
     end


### PR DESCRIPTION
It seems that the LAPACK team have updated the manpages tarball:

```
[vagrant@uiswhwks1290033 vagrant]$ brew install lapack
==> Installing lapack from homebrew/dupes
==> Using Homebrew-provided fortran compiler.
This may be changed by setting the FC environment variable.
==> Downloading http://www.netlib.org/lapack/lapack-3.6.0.tgz
Already downloaded: /home/vagrant/.cache/Homebrew/lapack-3.6.0.tgz
==> cmake . -DBUILD_SHARED_LIBS:BOOL=ON -DLAPACKE:BOOL=ON -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=
==> make install                 
==> Downloading http://netlib.org/lapack/manpages.tgz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 055da7402ea807cc16f6c50b71ac63d290f83a5f2885aa9f679b7ad11dd8903d
Actual: 96d6d37b49e01143cf27e1980534ee21e01de6e93c1455c63d1e0a799f799dcb
Archive: /home/vagrant/.cache/Homebrew/lapack--manpages-3.6.0.tgz
To retry an incomplete download, remove the file above.
```

I updated the formula with the current sha256sum hash.
Now it installs correctly:

```
[vagrant@uiswhwks1290033 ~]$ brew install lapack                                                                     ==> Installing lapack from homebrew/dupes
==> Using Homebrew-provided fortran compiler.
This may be changed by setting the FC environment variable.
==> Downloading http://www.netlib.org/lapack/lapack-3.6.0.tgz
Already downloaded: /home/vagrant/.cache/Homebrew/lapack-3.6.0.tgz
==> cmake . -DBUILD_SHARED_LIBS:BOOL=ON -DLAPACKE:BOOL=ON -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=
==> make install
==> Downloading http://netlib.org/lapack/manpages.tgz
Already downloaded: /home/vagrant/.cache/Homebrew/lapack--manpages-3.6.0.tgz
/home/vagrant/.linuxbrew/Cellar/lapack/3.6.0: 12,629 files, 27.7M, built in 6 minutes 21 seconds
```