### PR TITLE
fix configure: error: Cannot link with GPM library

### DIFF
--- a/ncurses.rb
+++ b/ncurses.rb
@@ -39,6 +39,7 @@ class Ncurses < Formula
                           "--mandir=#{man}",
                           "--with-manpage-format=normal",
                           "--with-shared"
+                          "--with-gpm=no"
     system "make", "install"
     make_libncurses_symlinks
 


### PR DESCRIPTION
When trying to install the readline package with Linuxbrew on CentOS, got error:
configure: error: Cannot link with GPM library
After adding "--with-gpm=no", installation was succeeded. 