### PR TITLE
krb5: Depends on bison for Linuxbrew

### DIFF
--- a/krb5.rb
+++ b/krb5.rb
@@ -13,6 +13,7 @@ class Krb5 < Formula
   keg_only :provided_by_osx
 
   depends_on "openssl"
+  depends_on "bison" unless OS.mac?
 
   def install
     cd "src" do


### PR DESCRIPTION
`brew gist-logs`: https://gist.github.com/anonymous/e1b9d43a1386298d012b57b96b14d5e3

Manifested by:

```
/usr/bin/gcc-4.8 -DHAVE_CONFIG_H  -I../../include -I../../include -I. -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -isystem/home/linuxbrew/.linuxbrew/include -Os -w -pipe -march=native -Wall -Wcast-align -Wshadow -Wmissing-prototypes -Wno-format-zero-length -Woverflow -Wstrict-overflow -Wmissing-format-attribute -Wmissing-prototypes -Wreturn-type -Wmissing-braces -Wparentheses -Wswitch -Wunused-function -Wunused-label -Wunused-variable -Wunused-value -Wunknown-pragmas -Wsign-compare -Werror=uninitialized -Werror=pointer-arith -Werror=declaration-after-statement -Werror-implicit-function-declaration -pthread -c ss_wrapper.c
yacc  getdate.y
make[2]: yacc: Command not found
make[2]: *** [getdate.c] Error 127
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/tmp/krb5-20160517-2322-123f1q2/krb5-1.14/src/kadmin/cli'
make[1]: *** [all-recurse] Error 1
make[1]: Leaving directory `/tmp/krb5-20160517-2322-123f1q2/krb5-1.14/src/kadmin'
make: *** [all-recurse] Error 1
```