### PR TITLE
[nano] updating HEAD to git repo

### DIFF
--- a/nano.rb
+++ b/nano.rb
@@ -13,7 +13,7 @@ class Nano < Formula
   end
 
   head do
-    url "git://git.savannah.gnu.org/nano.git"
+    url "http://git.savannah.gnu.org/r/nano.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
   end

--- a/nano.rb
+++ b/nano.rb
@@ -13,7 +13,7 @@ class Nano < Formula
   end
 
   head do
-    url "svn://svn.sv.gnu.org/nano/trunk/nano"
+    url "git://git.savannah.gnu.org/nano.git"
     depends_on "automake" => :build
     depends_on "autoconf" => :build
   end


### PR DESCRIPTION
Nano's source tree has been migrated to [`git`](http://www.nano-editor.org/git.php).


