### PR TITLE
file-formula: don't try to share libmagic

### DIFF
--- a/file-formula.rb
+++ b/file-formula.rb
@@ -8,6 +8,8 @@ class FileFormula < Formula
 
   head "https://github.com/file/file.git"
 
+  revision 1
+
   bottle do
     cellar :any
     sha256 "23e98e27a13e15e5f24c7c52fe7d6e0c49ec2cd53e572f4f2823a99af69eb593" => :el_capitan
@@ -17,14 +19,10 @@ class FileFormula < Formula
 
   keg_only :provided_by_osx
 
-  depends_on "libmagic"
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
-    system "make", "install-exec"
-    system "make", "-C", "doc", "install-man1"
-    rm_r lib
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
A previous commit (aa601b0) modified the formula to attempt to share the
library and database from the libmagic formula. Unfortunately, that doesn't
seem to work in all environments. In particular, with file 5.28 on el_capitan
in /opt/homebrew, file cannot be run:

    dyld: Library not loaded: /opt/homebrew/Cellar/file-formula/5.28/lib/libmagic.1.dylib
      Referenced from: /opt/homebrew/Cellar/file-formula/5.28/bin/file
      Reason: image not found

It doesn't look like there is out-of-the-box support for this in libmagic/file.
Even if there was, it might be tricky getting the versions right. I think
ideally we'd have a single brew which was part-keg-only, but I don't see a way
to do that either. I'm open to suggestions.

Test plan:

`brew install --build-from-source file-formula && brew test file-formula`