### PR TITLE
Update tcl-tk.rb

### DIFF
--- a/tcl-tk.rb
+++ b/tcl-tk.rb
@@ -35,7 +35,7 @@ class TclTk < Formula
 
   resource "tcllib" do
     url "https://github.com/tcltk/tcllib/archive/tcllib_1_18.tar.gz"
-    sha256 "6a87881f545afb69c1130f60984b5d35cc22f1593b0835b982871c188fde3de8"
+    sha256 "9988b4385403c2aac78743fd3fce2d22e82686a56e6ca25942cb83c7d9e641db"
   end
 
   # sqlite won't compile on Tiger due to missing function;

--- a/tcl-tk.rb
+++ b/tcl-tk.rb
@@ -34,8 +34,8 @@ class TclTk < Formula
   end
 
   resource "tcllib" do
-    url "https://github.com/tcltk/tcllib/archive/tcllib_1_18.tar.gz"
-    sha256 "9988b4385403c2aac78743fd3fce2d22e82686a56e6ca25942cb83c7d9e641db"
+    url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.18/tcllib-1.18.tar.gz"
+    sha256 "72667ecbbd41af740157ee346db77734d1245b41dffc13ac80ca678dd3ccb515"
   end
 
   # sqlite won't compile on Tiger due to missing function;

--- a/tcl-tk.rb
+++ b/tcl-tk.rb
@@ -5,6 +5,7 @@ class TclTk < Formula
   mirror "ftp://ftp.tcl.tk/pub/tcl/tcl8_6/tcl8.6.6-src.tar.gz"
   version "8.6.6"
   sha256 "a265409781e4b3edcc4ef822533071b34c3dc6790b893963809b9fe221befe07"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
The SHA256 is wrong for downloading https://github.com/tcltk/tcllib/archive/tcllib_1_18.tar.gz. I've put the corrected one in (error trace below):

==> Installing homebrew/science/pymol dependency: homebrew/dupes/tcl-tk

==> Downloading https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tcl8.6.6
==> Downloading from https://iweb.dl.sourceforge.net/project/tcl/Tcl/8.6.6/tcl8.
######################################################################## 100.0%
==> ./configure --prefix=/usr/local/Cellar/tcl-tk/8.6.6 --mandir=/usr/local/Cell
==> make
==> make install
==> make install-private-headers
==> Downloading https://downloads.sourceforge.net/project/tcl/Tcl/8.6.6/tk8.6.6-
==> Downloading from https://iweb.dl.sourceforge.net/project/tcl/Tcl/8.6.6/tk8.6
######################################################################## 100.0%
==> ./configure --prefix=/usr/local/Cellar/tcl-tk/8.6.6 --mandir=/usr/local/Cell
==> make TK_LIBRARY=/usr/local/Cellar/tcl-tk/8.6.6/lib
==> make install
==> make install-private-headers
==> Downloading https://github.com/tcltk/tcllib/archive/tcllib_1_18.tar.gz
==> Downloading from https://codeload.github.com/tcltk/tcllib/tar.gz/tcllib_1_18
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 6a87881f545afb69c1130f60984b5d35cc22f1593b0835b982871c188fde3de8
Actual: 9988b4385403c2aac78743fd3fce2d22e82686a56e6ca25942cb83c7d9e641db
Archive: /Users/thomasjames/Library/Caches/Homebrew/tcl-tk--tcllib-1.18.tar.gz
To retry an incomplete download, remove the file above.

