### PR TITLE
ntp 4.2.8p10: new formula

### DIFF
--- a/ntp.rb
+++ b/ntp.rb
@@ -1,0 +1,117 @@
+class Ntp < Formula
+  desc "The Network Time Protocol (NTP) Distribution"
+  homepage "https://www.eecis.udel.edu/~mills/ntp/html/"
+  # Arguments could be made for:
+  # http://ntp.org/documentation.html (has more unofficial stuff)
+  # http://ntp.org/  (more the protocol than the distribution)
+  url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
+  version "4.2.8p10"
+  sha256 "ddd2366e64219b9efa0f7438e06800d0db394ac5c88e13c17b70d0dcdf99b99f"
+
+  devel do
+    # http://support.ntp.org/bin/view/Main/SoftwareDevelopment
+    url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
+    sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
+  end
+
+  head do
+    ## The git repo is broken/ancient, per https://github.com/ntp-project/ntp/issues/17
+    ## but the others aren't much better.
+    #
+    ## url "https://github.com/ntp-project/ntp.git"
+    ## Default stable branch: 1a399a03e674da08cfce2cdb847bfb65d65df237, Jan 24 2016
+    ## Non-default "master" branch: 9c75327c3796ff59ac648478cd4da8b205bceb77 Sun Jan 24 12:06:39 2016 +0000
+    #
+    ## bk://bk.ntp.org/ntp-stable
+    ## (4.2.8p10-win-beta1) 2017/03/21 Released by Harlan Stenn <stenn@ntp.org>
+    #
+    ## bk://bk.ntp.org/ntp-dev
+    ## (4.3.93) 2016/06/02 Released by Harlan Stenn <stenn@ntp.org>
+    #
+    ## rsync archive.ntp.org::ntp-dev-src
+    ## (4.3.92) 2016/04/27 Released by Harlan Stenn <stenn@ntp.org>
+
+    # Unsupported syntax?: depends_on cask: "bitkeeper"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+    depends_on "lynx" => :build
+  end
+
+  depends_on "openssl"
+
+  def install
+    # Ensure homebrew perl is in #! lines of installed scripts.
+    ENV["PATH_PERL"] = "/usr/local/bin/perl"
+
+    system "./bootstrap" if build.head?
+
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-openssl-libdir=#{Formula["openssl"].lib}",
+                          "--with-openssl-incdir=#{Formula["openssl"].include}"
+
+    system "make", "install"
+  end
+
+  def caveats
+    s = <<-EOS.undent
+    By default, OS X ships a broken version of ntpd that by design
+    does not control the system clock, but maintains the network
+    protocol and is intended to write a drift file (which it fails to
+    do under OS X 10.10). The drift file is read by pacemaker(8),
+    which is supposed to call adjtime() in a battery-efficient fashion
+    for laptops.
+
+    Installing this formula implies disabling the system ntpd as well as pacemaker:
+
+    sudo launchctl disable system/com.apple.pacemaker
+    sudo launchctl disable system/org.ntp.ntpd
+    EOS
+    s
+  end
+
+  plist_options :startup => true
+
+  # OS X uses /usr/libexec/ntp-wrapper to wait for appropriate network conditions and then
+  # invoke ntpd with various args. It's not clear that we need to resort to that. It also
+  # runs sntp first, which is definitely unnecessary given ntpd -g.
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>KeepAlive</key>
+      <true/>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_sbin}/ntpd</string>
+        <string>-c</string>
+        <string>/private/etc/ntp-restrict.conf</string>
+        <string>-n</string>
+        <string>-g</string>
+        <string>-p</string>
+        <string>/var/run/ntpd.pid</string>
+        <string>-f</string>
+        <string>/var/db/ntp.drift</string>
+        <string>-l</string>
+        <string>/var/log/ntp.log</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+
+  test do
+    # It's hard to do anything without network or clock-invasive stuff.
+    # Make sure we can print a usage message.
+    assert_match "usage: ", shell_output("#{sbin}/ntpdate -\? 2>&1", 2)
+  end
+end

--- a/ntp.rb
+++ b/ntp.rb
@@ -39,7 +39,10 @@ class Ntp < Formula
     depends_on "lynx" => :build
   end
 
+  option "with-snmp", "Build SNMP support"
+
   depends_on "openssl"
+  depends_on "net-snmp" if build.with? "snmp"
 
   def install
     # Ensure homebrew perl is in #! lines of installed scripts.
@@ -48,12 +51,17 @@ class Ntp < Formula
 
     system "./bootstrap" if build.head?
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--with-openssl-libdir=#{Formula["openssl"].lib}",
-                          "--with-openssl-incdir=#{Formula["openssl"].include}"
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}",
+      "--with-openssl-libdir=#{Formula["openssl"].lib}",
+      "--with-openssl-incdir=#{Formula["openssl"].include}",
+    ]
+    args << (build.with?("snmp") ? "-with-net-snmp-config" : "-with-net-snmp-config=no")
+
+    system "./configure", *args
 
     system "make", "install"
   end

--- a/ntp.rb
+++ b/ntp.rb
@@ -69,8 +69,8 @@ class Ntp < Formula
 
     Installing this formula implies disabling the system ntpd as well as pacemaker:
 
-    sudo launchctl disable system/com.apple.pacemaker
-    sudo launchctl disable system/org.ntp.ntpd
+      sudo launchctl disable system/com.apple.pacemaker
+      sudo launchctl disable system/org.ntp.ntpd
     EOS
     s
   end

--- a/ntp.rb
+++ b/ntp.rb
@@ -4,13 +4,13 @@ class Ntp < Formula
   # Arguments could be made for:
   # http://ntp.org/documentation.html (has more unofficial stuff)
   # http://ntp.org/  (more the protocol than the distribution)
-  url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
+  url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p10.tar.gz"
   version "4.2.8p10"
   sha256 "ddd2366e64219b9efa0f7438e06800d0db394ac5c88e13c17b70d0dcdf99b99f"
 
   devel do
     # http://support.ntp.org/bin/view/Main/SoftwareDevelopment
-    url "http://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
+    url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-dev/ntp-dev-4.3.93.tar.gz"
     sha256 "a07e73d7a3ff139bba33ee4b1110d5f3f4567465505d6317c9b50eefb9720c42"
   end
 

--- a/ntp.rb
+++ b/ntp.rb
@@ -43,7 +43,8 @@ class Ntp < Formula
 
   def install
     # Ensure homebrew perl is in #! lines of installed scripts.
-    ENV["PATH_PERL"] = "/usr/local/bin/perl"
+    localperl="/usr/local/bin/perl"
+    ENV["PATH_PERL"] = localperl if File.exist? localperl
 
     system "./bootstrap" if build.head?
 


### PR DESCRIPTION
The Network Time Protocol (NTP) Distribution.

This is a little tricky since:

* It replaces a MacOS component that is thoroughly busted. I'm sure it's thoroughly busted under 10.10 and under the strong impression that hasn't changed under 10.11 or 10.12, but I still live my life in Yosemite so I'm not really in a position to test that. I've been running the stock ntpd on my Yosemite machine for years, never bothered to package it though.

* It requires disabling the existing ntpd, which doesn't quite work in the `brew services `regime. Hopefully the use of Caveats is appropriate here -- I would assume so since the presence of the plist file causes `brew services` directions to be appended to the Caveats. The result is 3 things the user has to do.

---

Also, I set `PATH_PERL`  to `/usr/local/bin/perl` because I want the installed perl scripts (`ntptrace`, `ntpq`) not to crash on my system when `PERL5LIB` is set. I have a suspicion there might be an objection to this (although I'm not exactly sure why), but if so, please let me know what a useful remedy is that doesn't break those scripts on my system.

Furthermore, the upstream alleges 3 mirrored repositories (github, bitkeeper, rsync), and they are a) not mirrored and b) not up to date. I'm not sure what's going on there, maybe security issues for recent vulnerabilities? The bitkeeper repos are the most up-to-date, but it doesn't seem worth figuring out how to make that work in the formula since it doesn't actually gain anything. (Also the github repo is "special" because the default branch is `stable` and you need to explicitly check out `master` and I'm not sure what the right syntax for that is in homebrew's world.)

